### PR TITLE
Add Github workflow to run the raffle

### DIFF
--- a/.github/workflows/raffle.yml
+++ b/.github/workflows/raffle.yml
@@ -1,0 +1,23 @@
+name: raffle
+
+# TODO update this for a specific week day / time
+on: [push, pull_request]
+
+jobs:
+  raffle:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - name: Set up python environment
+      uses: actions/setup-python@v2.3.1
+      with:
+        python-version: "3.10"
+    - name: Install pip dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/requirements.txt
+    - name: Launch raffle
+      run: |
+        python raffle.py


### PR DESCRIPTION
Simple workflow to run the raffle. This allows us to have the code open source, and run the raffle at a specific time when the `on` parameter is updated. Thus, everyone can check if the raffle is random and correct :blush: 